### PR TITLE
fix settings.py example for attributemaps

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -96,7 +96,7 @@ SAML_CONFIG = {
   'entityid': 'http://YOU/saml2/metadata/',
 
   # directory with attribute mapping
-  'attribute_map_dir': path.join(BASEDIR, 'attribute-maps'),
+  'attribute_map_dir': path.join(BASEDIR, 'attributemaps'),
 
   # this block states what services we provide
   'service': {


### PR DESCRIPTION
Otherwise sal fails to load the saml URL's correctly.