### PR TITLE
Signals

### DIFF
--- a/Dockerfile.pristine
+++ b/Dockerfile.pristine
@@ -9,3 +9,5 @@ RUN pip install git+git://github.com/francoisfreitag/djangosaml2.git@613356c7f0e
 ADD attributemaps /home/app/sal/sal/attributemaps
 RUN mv /home/app/sal/sal/urls.py /home/app/sal/sal/origurls.py
 ADD urls.py /home/app/sal/sal/urls.py
+ADD apps.py /home/app/sal/server/apps.py
+ADD signals.py /home/app/sal/server/signals.py

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Sal-saml adds a Django signal callback to act on group membership information pa
 
 To take advantage of this, edit the settings.py that comes with sal-saml for these preferences:
 - `SAML_GROUPS_ATTRIBUTE`: Default (`memberOf`) The assertion dict's key for the group membership attribute.
-    - `SAML_READ_ONLY_GROUPS`: Default `[]` (empty list) List of groups who should be given read-only access.
-    - `SAML_READ_WRITE_GROUPS`: Default `[]` (empty list) List of groups who should be given read-write access.
-    - `SAML_GLOBAL_ADMIN_GROUPS` Default `[]` (empty list) List of groups who should be given global admin access.
+- `SAML_READ_ONLY_GROUPS`: Default `[]` (empty list) List of groups who should be given read-only access.
+- `SAML_READ_WRITE_GROUPS`: Default `[]` (empty list) List of groups who should be given read-write access.
+- `SAML_GLOBAL_ADMIN_GROUPS` Default `[]` (empty list) List of groups who should be given global admin access.
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ _The following instructions are provided as a best effort to help get started. T
     - `single_sign_on_service` Ex: https://apps.onelogin.com/trust/saml2/http-post/sso/1234567890
     - `single_logout_service` Ex: https://apps.onelogin.com/trust/saml2/http-redirect/slo/1234567890
 
+## Using groups in the SAML assertion to assign Sal profiles
+Sal-saml adds a Django signal callback to act on group membership information passed in a SAML assertion during login. If you can configure your IdP to add group information, you can use it to automate the addition and revocation of permissions.
+
+To take advantage of this, edit the settings.py that comes with sal-saml for these preferences:
+- `SAML_GROUPS_ATTRIBUTE`: Default (`memberOf`) The assertion dict's key for the group membership attribute.
+    - `SAML_READ_ONLY_GROUPS`: Default `[]` (empty list) List of groups who should be given read-only access.
+    - `SAML_READ_WRITE_GROUPS`: Default `[]` (empty list) List of groups who should be given read-write access.
+    - `SAML_GLOBAL_ADMIN_GROUPS` Default `[]` (empty list) List of groups who should be given global admin access.
+
+For example:
+```
+SAML_READ_ONLY_GROUPS = ['cn=regular_shorts_wearers,ou=memberOf,dc=blutwurst,dc=com', 'cn=nontraditional_pants_krew,ou=memberOf,dc=blutwurst,dc=com']
+SAML_GLOBAL_ADMIN_GROUPS` = ['cn=lederhosen_club,ou=memberOf,dc=blutwurst,dc=com']
+```
+
 ## An example Docker run
 
 Please note that this docker run is **incomplete**, but shows where to pass the `metadata.xml` and `settings.py`. Also note, `latest` in the below run should not be used unless you have a real reason (needing a development version). When performing `docker run`, you should substitute `latest` for the latest tagged release.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To take advantage of this, edit the settings.py that comes with sal-saml for the
 - `SAML_GROUPS_ATTRIBUTE`: Default (`memberOf`) The assertion dict's key for the group membership attribute.
 - `SAML_READ_ONLY_GROUPS`: Default `[]` (empty list) List of groups who should be given read-only access.
 - `SAML_READ_WRITE_GROUPS`: Default `[]` (empty list) List of groups who should be given read-write access.
-- `SAML_GLOBAL_ADMIN_GROUPS` Default `[]` (empty list) List of groups who should be given global admin access.
+- `SAML_GLOBAL_ADMIN_GROUPS` Default `[]` (empty list) List of groups who should be given global admin access. This includes access to the admin site.
 
 For example:
 ```

--- a/apps.py
+++ b/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ServerAppConfig(AppConfig):
+    name = "server"
+
+    def ready(self):
+        import server.signals

--- a/process_build.py
+++ b/process_build.py
@@ -25,7 +25,8 @@ RUN pip install git+git://github.com/francoisfreitag/djangosaml2.git@613356c7f0e
 ADD attributemaps /home/app/sal/sal/attributemaps
 RUN mv /home/app/sal/sal/urls.py /home/app/sal/sal/origurls.py
 ADD urls.py /home/app/sal/sal/urls.py
-
+ADD apps.py /home/app/sal/server/apps.py
+ADD signals.py /home/app/sal/server/signals.py
 """.format(tag)
 
 with open("Dockerfile", "w") as dockerfile:

--- a/settings.py
+++ b/settings.py
@@ -92,8 +92,10 @@ SAML_CONFIG = {
   # directory with attribute mapping
   'attribute_map_dir': path.join(BASEDIR, 'attributemaps'),
 
-  # this block states what services we provide
+  # Allow SAML assertions to contain attributes not specified in the
+  # attributemaps.
   'allow_unknown_attributes': True,
+  # this block states what services we provide
   'service': {
       # we are just a lonely SP
       'sp' : {
@@ -104,7 +106,7 @@ SAML_CONFIG = {
           'name': 'Federated Django sample SP',
           'name_id_format': NAMEID_FORMAT_PERSISTENT,
           'endpoints': {
-              # url and binding to the assetion consumer service view
+              # url and binding to the assertion consumer service view
               # do not change the binding or service name
               'assertion_consumer_service': [
                   ('https://sal.example.com/saml2/acs/',

--- a/settings.py
+++ b/settings.py
@@ -21,6 +21,7 @@ SAML_ATTRIBUTE_MAPPING = {
 
 # Edit these lists to include the names of groups that should get
 # the access levels below. See server/signals.py for more details.
+# Leave blank to disable the group-based permissions feature.
 SAML_READ_ONLY_GROUPS = []
 SAML_READ_WRITE_GROUPS = []
 SAML_GLOBAL_ADMIN_GROUPS = []

--- a/settings.py
+++ b/settings.py
@@ -19,6 +19,15 @@ SAML_ATTRIBUTE_MAPPING = {
     'sn': ('last_name', ),
 }
 
+# Edit these lists to include the names of groups that should get
+# the access levels below. See server/signals.py for more details.
+SAML_READ_ONLY_GROUPS = []
+SAML_READ_WRITE_GROUPS = []
+SAML_GLOBAL_ADMIN_GROUPS = []
+# Edit to match the attribute name used in your SAML assertions for
+# group membership information.
+SAML_GROUPS_ATTRIBUTE = 'memberOf'
+
 logging_config = get_sal_logging_config()
 level = 'DEBUG' if DEBUG == True else 'ERROR'
 logging_config['loggers']['djangosaml2'] = {

--- a/signals.py
+++ b/signals.py
@@ -43,6 +43,7 @@ def update_group_membership(
         instance.userprofile.delete()
         user_profile = UserProfile(user=instance, level=ProfileLevel.global_admin)
         user_profile.save()
+        instance.is_superuser = True
         instance.is_staff = True
         instance.is_active = True
         user_modified = True
@@ -50,6 +51,7 @@ def update_group_membership(
         instance.userprofile.delete()
         user_profile = UserProfile(user=instance, level=ProfileLevel.read_write)
         user_profile.save()
+        instance.is_superuser = False
         instance.is_staff = False
         instance.is_active = True
         user_modified = True
@@ -57,6 +59,7 @@ def update_group_membership(
         instance.userprofile.delete()
         user_profile = UserProfile(user=instance, level=ProfileLevel.read_only)
         user_profile.save()
+        instance.is_superuser = False
         instance.is_staff = False
         instance.is_active = True
         user_modified = True

--- a/signals.py
+++ b/signals.py
@@ -1,5 +1,3 @@
-from typing import Set
-
 from django.dispatch import receiver
 
 from djangosaml2.signals import pre_user_save

--- a/signals.py
+++ b/signals.py
@@ -1,0 +1,65 @@
+from typing import Set
+
+from django.dispatch import receiver
+
+from djangosaml2.signals import pre_user_save
+
+from server.models import UserProfile, ProfileLevel
+from server.utils import get_django_setting
+
+
+READ_ONLY_GROUPS = set(get_django_setting('SAML_READ_ONLY_GROUPS', []))
+READ_WRITE_GROUPS = set(get_django_setting('SAML_READ_WRITE_GROUPS', []))
+GLOBAL_ADMIN_GROUPS = set(get_django_setting('SAML_GLOBAL_ADMIN_GROUPS', []))
+GROUPS_ATTRIBUTE = get_django_setting('SAML_GROUPS_ATTRIBUTE', 'memberOf')
+
+
+@receiver(pre_user_save)
+def update_group_membership(
+        sender, instance, attributes: dict, user_modified: bool, **kwargs) -> bool:
+    """Update user's group membership based on passed SAML groups
+
+    Sal access level is based on the highest access level granted across
+    all groups a user is a member of. For example, if you are in a group
+    with RO access and a group with GA access, the GA level "wins".
+
+    Users who have no group membership in any of the configured
+    SAML_X_GROUPS settings will be unchanged, allowing changes to these
+    users via the admin panel to persist.
+
+    Args:
+        sender: The class of the user that just logged in.
+        instance: User instance
+        attributes: SAML attributes dict.
+        user_modified: Bool whether the user has been modified
+        kwargs:
+            signal: The signal instance
+
+    Returns:
+        Whether or not the user has been modified. This allows the user
+        instance to be saved once at the conclusion of the auth process
+        to keep the writes to a minimum.
+    """
+    assertion_groups = set(attributes.get(GROUPS_ATTRIBUTE, []))
+    if GLOBAL_ADMIN_GROUPS.intersection(assertion_groups):
+        instance.userprofile.delete()
+        user_profile = UserProfile(user=instance, level=ProfileLevel.global_admin)
+        user_profile.save()
+        instance.is_staff = True
+        instance.is_active = True
+        user_modified = True
+    elif READ_WRITE_GROUPS.intersection(assertion_groups):
+        instance.userprofile.delete()
+        user_profile = UserProfile(user=instance, level=ProfileLevel.read_write)
+        user_profile.save()
+        instance.is_staff = False
+        instance.is_active = True
+        user_modified = True
+    elif READ_ONLY_GROUPS.intersection(assertion_groups):
+        instance.userprofile.delete()
+        user_profile = UserProfile(user=instance, level=ProfileLevel.read_only)
+        user_profile.save()
+        instance.is_staff = False
+        instance.is_active = True
+        user_modified = True
+    return user_modified


### PR DESCRIPTION
This PR adds a Django signal watcher that allows Sal users' profile level (i.e. RO, RW, or GA), staff, and active attributes to be updated based on group membership provided by the SAML assertion returned by a successful SAML auth during login.

Along with this change comes four new settings.py settings; group lists for each profile level, and a pref specifying the name to use to acces the SAML assertion's group membership attribute.

The signals.py will only take action on users who are members of one of the three configured types of groups. Local users or SAML users who are not members of any of the groups are left alone. This allows admins to create local Django users for testing, or to manually add SAML users to particular access levels who otherwise wouldn't have access.

This creates the responsibility to ensure that the SAML IdP does not allow users to login if they shouldn't have access. While this probably goes without saying, if you allow all SAML authed users access, any users who have no group membership in one of the three configured groups will get the default profile level and access. However, if any of these users _previously_ were members of any of the configured groups, they will retain that profile level and staff status, which the removal from the configured group was probably intended to revoke.

TL;DR use your SAML provider to limit access and the `SAML_READ_ONLY_GROUPS` setting to ensure that everyone who can login who shouldn't have admin rights gets properly handled.