### PR TITLE
correct typo in settings.py

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -23,7 +23,7 @@ logging_config = get_sal_logging_config()
 level = 'DEBUG' if DEBUG == True else 'ERROR'
 logging_config['loggers']['djangosaml2'] = {
     'propagate': False, 'handlers': ['console'], 'level': level}
-update_sal_loggin_config(logging_config)
+update_sal_logging_config(logging_config)
 
 
 INSTALLED_APPS += ('djangosaml2',)


### PR DESCRIPTION
Hi folks, 
While migrating a sal-saml setup from 3.3.16 to 4.1.2 I discovered this small typo in the example **settings.py** which result in a failing service. 

Following return errors you catch if you still go with the wrong function name:

`/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 325, in execute
    settings.INSTALLED_APPS
  File "/usr/local/lib/python3.7/site-packages/django/conf/__init__.py", line 79, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python3.7/site-packages/django/conf/__init__.py", line 66, in _setup
    self._wrapped = Settings(settings_module)
  File "/usr/local/lib/python3.7/site-packages/django/conf/__init__.py", line 157, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/docker/sal/sal/settings.py", line 26, in <module>
    update_sal_loggin_config(logging_config)
NameError: name 'update_sal_loggin_config' is not defined`

