### PR TITLE
Remove ENVVAR DJANGO_SAML_VERSION

### DIFF
--- a/Dockerfile.pristine
+++ b/Dockerfile.pristine
@@ -1,6 +1,5 @@
 FROM macadmins/sal:latest
 MAINTAINER Graham Gilbert <graham@grahamgilbert.com>
-ENV DJANGO_SAML_VERSION 0.16.11
 
 RUN apt-get update && apt-get install -y python-setuptools python-dev libxmlsec1-dev libxml2-dev xmlsec1 python-pip
 RUN pip install -U setuptools

--- a/process_build.py
+++ b/process_build.py
@@ -16,7 +16,6 @@ if tag == "":
         tag = os.getenv("CIRCLE_BRANCH")
 dockerfile_content = """FROM macadmins/sal:{}
 MAINTAINER Graham Gilbert <graham@grahamgilbert.com>
-ENV DJANGO_SAML_VERSION 0.16.11
 
 RUN apt-get update && apt-get install -y python-setuptools python-dev libxmlsec1-dev libxml2-dev xmlsec1 python-pip
 RUN pip install -U setuptools


### PR DESCRIPTION
The following removes `ENV DJANGO_SAML_VERSION 0.16.11` as it's explicitly set as part of the install pip command, it looks like this was previously used as per the following historical commit. https://github.com/salopensource/sal-saml/blob/65fc72aa2231121459892cd339affd1a8381d1df/Dockerfile